### PR TITLE
BAU: Node.js 20 Actions Deprecation Fix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ outputs:
   env_name: 
      description: A property named after `env_name` with the value from the file.
 runs:
-  using: 'node16'
+  using: 'node24'
   main: 'index.js'


### PR DESCRIPTION
This is fix for the GH Action to fix the Node.js 20 actions are deprecated. warning shown during GH Action execution.